### PR TITLE
Send and receive config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:scheme="file"
+                    android:mimeType="@string/data_mime_type"
+                    android:host="*"
+                    android:pathPattern=".*\\.json" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/xargsgrep/portknocker/activity/HostListActivity.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/activity/HostListActivity.java
@@ -143,6 +143,9 @@ public class HostListActivity extends ActionBarActivity
                 Intent intent = Intent.createChooser(getContentIntent, "Select a file");
                 startActivityForResult(intent, FILE_CHOOSER_REQUEST_CODE);
                 return true;
+            case R.id.menu_item_send:
+                sendHostsToOtherApp();
+                return true;
             case R.id.menu_item_sort_hostname:
                 ((HostListFragment) hostListFragment).sortByHostname();
                 return true;
@@ -194,6 +197,26 @@ public class HostListActivity extends ActionBarActivity
         });
 
         alert.show();
+    }
+
+    private void sendHostsToOtherApp() {
+        List<Host> hosts = databaseManager.getAllHosts();
+        try {
+            // Sharing per e-mail app but also others works reliable only by using a file
+            String path = SerializationUtils.serializeHosts("PortKnockerConfig.json", hosts);
+
+            Intent shareIntent = new Intent();
+            Uri uriToCsvFile = Uri.parse(path);
+            shareIntent.setAction(Intent.ACTION_SEND);
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uriToCsvFile);
+            shareIntent.setType("application/json");
+
+            startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.share_dialog_chooser_title)));
+        }
+        catch (Exception e)
+        {
+            showToast(getString(R.string.export_host_dialog_export_failure) + e.getMessage());
+        }
     }
 
     @Override

--- a/app/src/main/java/com/xargsgrep/portknocker/asynctask/RetrieveApplicationsAsyncTask.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/asynctask/RetrieveApplicationsAsyncTask.java
@@ -53,6 +53,7 @@ public class RetrieveApplicationsAsyncTask extends AsyncTask<Void, Void, List<Ap
         Fragment prev = fragmentManager.findFragmentByTag(ProgressDialogFragment.TAG);
         if (prev != null) ft.remove(prev);
         ft.addToBackStack(null);
+        ft.commit();
 
 //        ProgressDialogFragment dialogFragment = ProgressDialogFragment.newInstance(activity.getString(R.string.progress_dialog_retrieving_applications), true, ProgressDialog.STYLE_SPINNER);
 //        dialogFragment.setCancelable(false);

--- a/app/src/main/java/com/xargsgrep/portknocker/db/DatabaseManager.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/db/DatabaseManager.java
@@ -77,7 +77,7 @@ public class DatabaseManager
                 DatabaseHelper.HOST_TABLE_NAME,
                 DatabaseHelper.HOST_TABLE_COLUMNS,
                 hostSelection,
-                new String[] {new Long(hostId).toString()},
+                new String[] {Long.toString(hostId)},
                 null,
                 null,
                 DatabaseHelper.HOST_ID_COLUMN
@@ -152,11 +152,11 @@ public class DatabaseManager
             hostValues.put(DatabaseHelper.HOST_TCP_CONNECT_TIMEOUT_COLUMN, host.getTcpConnectTimeout());
 
             String hostSelection = String.format("%s = ?", DatabaseHelper.HOST_ID_COLUMN);
-            int rowsAffected = database.update(DatabaseHelper.HOST_TABLE_NAME, hostValues, hostSelection, new String[] {new Long(host.getId()).toString()});
+            int rowsAffected = database.update(DatabaseHelper.HOST_TABLE_NAME, hostValues, hostSelection, new String[] {Long.toString(host.getId())});
             if (rowsAffected == 0) return false;
 
             String portsSelection = String.format("%s = ?", DatabaseHelper.PORT_HOST_ID_COLUMN);
-            database.delete(DatabaseHelper.PORT_TABLE_NAME, portsSelection, new String[] {new Long(host.getId()).toString()});
+            database.delete(DatabaseHelper.PORT_TABLE_NAME, portsSelection, new String[] {Long.toString(host.getId())});
 
             int i = 0;
             for (Port port : host.getPorts())
@@ -191,10 +191,10 @@ public class DatabaseManager
         try
         {
             String portsSelection = String.format("%s = ?", DatabaseHelper.PORT_HOST_ID_COLUMN);
-            database.delete(DatabaseHelper.PORT_TABLE_NAME, portsSelection, new String[] {new Long(host.getId()).toString()});
+            database.delete(DatabaseHelper.PORT_TABLE_NAME, portsSelection, new String[] {Long.toString(host.getId())});
 
             String hostSelection = String.format("%s = ?", DatabaseHelper.HOST_ID_COLUMN);
-            database.delete(DatabaseHelper.HOST_TABLE_NAME, hostSelection, new String[] {new Long(host.getId()).toString()});
+            database.delete(DatabaseHelper.HOST_TABLE_NAME, hostSelection, new String[] {Long.toString(host.getId())});
 
             database.setTransactionSuccessful();
         }
@@ -214,7 +214,7 @@ public class DatabaseManager
                 DatabaseHelper.HOST_TABLE_NAME,
                 DatabaseHelper.HOST_TABLE_COLUMNS,
                 hostSelection,
-                new String[] {new Long(hostId).toString()},
+                new String[] {Long.toString(hostId)},
                 null,
                 null,
                 DatabaseHelper.HOST_ID_COLUMN
@@ -236,7 +236,7 @@ public class DatabaseManager
                 DatabaseHelper.PORT_TABLE_NAME,
                 DatabaseHelper.PORT_TABLE_COLUMNS,
                 portsSelection,
-                new String[] {new Long(hostId).toString()},
+                new String[] {Long.toString(hostId)},
                 null,
                 null,
                 DatabaseHelper.PORT_INDEX_COLUMN

--- a/app/src/main/res/layout/host_fragment.xml
+++ b/app/src/main/res/layout/host_fragment.xml
@@ -27,8 +27,7 @@
         android:paddingRight="8dp"
         android:hint="@string/host_label_hint"
         android:inputType="text"
-        android:singleLine="true"
-        />
+        android:maxLines="1" />
 
     <TextView
         style="@style/labelSmall"
@@ -48,7 +47,6 @@
         android:paddingRight="8dp"
         android:hint="@string/host_name_hint"
         android:inputType="text"
-        android:singleLine="true"
-        />
+        android:maxLines="1" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/host_row.xml
+++ b/app/src/main/res/layout/host_row.xml
@@ -27,29 +27,26 @@
             android:id="@+id/host_row_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:singleLine="true"
             android:textColor="#FFFFFF"
             android:textSize="18sp"
-            />
+            android:maxLines="1" />
 
         <TextView
             android:id="@+id/host_row_hostname"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:singleLine="true"
             android:textColor="#888888"
             android:textSize="14sp"
-            />
+            android:maxLines="1" />
 
         <TextView
             android:id="@+id/host_row_ports"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:singleLine="true"
             android:textColor="#888888"
             android:textSize="14sp"
-            />
+            android:maxLines="1" />
     </LinearLayout>
 
     <ImageView

--- a/app/src/main/res/layout/port_row.xml
+++ b/app/src/main/res/layout/port_row.xml
@@ -27,8 +27,7 @@
             android:hint="@string/port_hint"
             android:inputType="number"
             android:maxLength="5"
-            android:singleLine="true"
-            />
+            android:maxLines="1" />
 
         <Spinner
             android:id="@+id/port_row_protocol"

--- a/app/src/main/res/menu/host_list.xml
+++ b/app/src/main/res/menu/host_list.xml
@@ -19,6 +19,11 @@
         android:title="@string/menu_item_import_title"
         app:showAsAction="never"
         />
+    <item
+        android:id="@+id/menu_item_send"
+        android:title="@string/menu_item_send_title"
+        app:showAsAction="never"
+        />
 
     <item
         android:icon="@drawable/ic_sort_variant"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,6 +50,7 @@
     <string name="menu_item_settings_title">Einstellungen</string>
     <string name="menu_item_export_title">Exportiere Hostliste</string>
     <string name="menu_item_import_title">Importiere Hostliste</string>
+    <string name="menu_item_send_title">Sende Hostliste</string>
     <string name="menu_item_sort_title">Sortiere Hostliste</string>
     <string name="menu_item_sort_hostname_title">Nach Hostname</string>
     <string name="menu_item_sort_label_title">Nach Titel</string>
@@ -60,4 +61,5 @@
     <string name="export_host_dialog_cancel_button">Abbrechen</string>
     <string name="export_host_dialog_export_complete">"Hostliste exportiert in file: "</string>
     <string name="export_host_dialog_export_failure">"Exportieren von Hostliste fehlgeschlagen: "</string>
+    <string name="share_dialog_chooser_title">"Teile mit... "</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="menu_item_settings_title">Settings</string>
     <string name="menu_item_export_title">Export Hosts</string>
     <string name="menu_item_import_title">Import Hosts</string>
+    <string name="menu_item_send_title">Send Hosts</string>
     <string name="menu_item_sort_title">Sort Hosts</string>
     <string name="menu_item_sort_hostname_title">By hostname</string>
     <string name="menu_item_sort_label_title">By label</string>
@@ -60,4 +61,5 @@
     <string name="export_host_dialog_cancel_button">Cancel</string>
     <string name="export_host_dialog_export_complete">"Exported hosts to file: "</string>
     <string name="export_host_dialog_export_failure">"Exporting hosts failed: "</string>
+    <string name="share_dialog_chooser_title">"Share with... "</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,4 +62,5 @@
     <string name="export_host_dialog_export_complete">"Exported hosts to file: "</string>
     <string name="export_host_dialog_export_failure">"Exporting hosts failed: "</string>
     <string name="share_dialog_chooser_title">"Share with... "</string>
+    <string name="data_mime_type" translatable="false">application/octet-stream</string>
 </resources>


### PR DESCRIPTION
Hi,
my final contribution for Port Knocker: Sending and receiving config directly from the app. As such per "Send hostlist" directly e-mail, bluetooth, android beam or any other app that can handle "application/octet-stream" mime-types can be used to send the host-list. Port Knocker is as well filtering for files of that mime-type with extension "*.json", so can directly take the config from e-mail or other content providers.
Also fixed a few points shown up by Lint code analysis.
Hope you can push to play-store so I can use the official one from play.
Thanks!