### PR TITLE
Fixed send and receive functionality for Android 6 and above.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     >
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
@@ -27,8 +28,21 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:scheme="file"
-                    android:mimeType="@string/data_mime_type"
+                    android:mimeType="application/octet-stream"
                     android:host="*"
+                    android:pathPattern=".*\\.json" />
+            </intent-filter>
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:scheme="content"
+                    android:mimeType="application/octet-stream"
+                    android:pathPattern=".*\\.json" />
+                <data
+                    android:scheme="content"
+                    android:mimeType="application/json"
                     android:pathPattern=".*\\.json" />
             </intent-filter>
         </activity>
@@ -135,6 +149,16 @@
             <intent-filter>
                 <action android:name="android.content.action.DOCUMENTS_PROVIDER"/>
             </intent-filter>
+        </provider>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.xargsgrep.portknocker.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
         </provider>
 
     </application>

--- a/app/src/main/java/com/xargsgrep/portknocker/utils/SerializationUtils.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/utils/SerializationUtils.java
@@ -1,6 +1,7 @@
 package com.xargsgrep.portknocker.utils;
 
 import android.os.Environment;
+import android.support.annotation.NonNull;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,11 +24,7 @@ public class SerializationUtils
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
 
-        File storageDir = new File(Environment.getExternalStorageDirectory(), "PortKnocker");
-        if (!storageDir.exists())
-        {
-            storageDir.mkdirs();
-        }
+        File storageDir = createPortKnockerFolderIfNotExists();
 
         File file = new File(storageDir, fileName);
         FileWriter fileWriter = new FileWriter(file);
@@ -35,6 +32,16 @@ public class SerializationUtils
         mapper.writeValue(fileWriter, hosts);
 
         return file.getAbsolutePath();
+    }
+
+    @NonNull
+    public static File createPortKnockerFolderIfNotExists() {
+        File storageDir = new File(Environment.getExternalStorageDirectory(), "PortKnocker");
+        if (!storageDir.exists())
+        {
+            storageDir.mkdirs();
+        }
+        return storageDir;
     }
 
     public static List<Host> deserializeHosts(String filePath) throws Exception

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -47,6 +47,9 @@
     <string name="toast_msg_knocking_complete">Anklopfen komplett</string>
     <string name="toast_msg_knocking_canceled">Anklopfen abgebrochen</string>
     <string name="toast_msg_knocking_failed">\"Anklopfen fehlgeschlagen: \"</string>
+    <string name="toast_msg_import_from_file_success">"Importiert aus: "</string>
+    <string name="toast_msg_import_error">"Import fehlgeschlagen: "</string>
+    <string name="toast_msg_no_permission_for_external_mem_access">Keine Rechte um auf externen Speicher zuzugreifen.</string>
     <string name="menu_item_settings_title">Einstellungen</string>
     <string name="menu_item_export_title">Exportiere Hostliste</string>
     <string name="menu_item_import_title">Importiere Hostliste</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,9 @@
     <string name="toast_msg_knocking_complete">Knocking complete</string>
     <string name="toast_msg_knocking_canceled">Knocking canceled</string>
     <string name="toast_msg_knocking_failed">"Knocking failed: "</string>
+    <string name="toast_msg_import_from_file_success">"Imported hosts from file: "</string>
+    <string name="toast_msg_import_error">"Importing hosts failed: "</string>
+    <string name="toast_msg_no_permission_for_external_mem_access">No permission to access external memory.</string>
     <string name="menu_item_settings_title">Settings</string>
     <string name="menu_item_export_title">Export Hosts</string>
     <string name="menu_item_import_title">Import Hosts</string>
@@ -62,5 +65,4 @@
     <string name="export_host_dialog_export_complete">"Exported hosts to file: "</string>
     <string name="export_host_dialog_export_failure">"Exporting hosts failed: "</string>
     <string name="share_dialog_chooser_title">"Share with... "</string>
-    <string name="data_mime_type" translatable="false">application/octet-stream</string>
 </resources>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="share" path="PortKnocker/" />
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Have an Android 6 phone now and found a number of issues with the last send/receive implementation and additional coded needed for access rights to external memory:

Rights management forbids file scheme sharing and instead we need to use content schemes. Filters adapted accordingly.

Additionally the application must request for external memory read/write rights, regardless of the manifest settings. Certain functionality (import, export, send, receive) is blocked as long as rights are not given.