### PR TITLE
Fix filehandling android 7

### DIFF
--- a/FileChooser/build.gradle
+++ b/FileChooser/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
     }
 
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.1.1'
+    compile 'com.android.support:support-v4:25.4.0'
 }

--- a/FileChooser/src/main/java/com/ipaulpro/afilechooser/FileChooserActivity.java
+++ b/FileChooser/src/main/java/com/ipaulpro/afilechooser/FileChooserActivity.java
@@ -30,6 +30,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentManager.BackStackEntry;
 import android.support.v4.app.FragmentManager.OnBackStackChangedListener;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.FileProvider;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -172,7 +173,10 @@ public class FileChooserActivity extends FragmentActivity implements
      */
     private void finishWithResult(File file) {
         if (file != null) {
-            Uri uri = Uri.fromFile(file);
+            Uri uri = FileProvider.getUriForFile(this.getBaseContext(), "com.ipaulpro.afilechooser", file);
+            Intent newIntent = new Intent();
+            newIntent.setData(uri);
+            newIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION + Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             setResult(RESULT_OK, new Intent().setData(uri));
             finish();
         } else {

--- a/FileChooser/src/main/java/com/ipaulpro/afilechooser/FileChooserActivity.java
+++ b/FileChooser/src/main/java/com/ipaulpro/afilechooser/FileChooserActivity.java
@@ -174,9 +174,6 @@ public class FileChooserActivity extends FragmentActivity implements
     private void finishWithResult(File file) {
         if (file != null) {
             Uri uri = FileProvider.getUriForFile(this.getBaseContext(), "com.ipaulpro.afilechooser", file);
-            Intent newIntent = new Intent();
-            newIntent.setData(uri);
-            newIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION + Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             setResult(RESULT_OK, new Intent().setData(uri));
             finish();
         } else {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.xargsgrep.portknocker"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 12
         versionName "1.0.11"
@@ -35,6 +35,6 @@ dependencies {
     compile project(':FileChooser')
 
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,24 +26,17 @@
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:scheme="file"
-                    android:mimeType="application/octet-stream"
-                    android:host="*"
-                    android:pathPattern=".*\\.json" />
+                <data android:scheme="file"/>
+                <data android:mimeType="application/octet-stream"/>
+                <data android:mimeType="application/json" />
             </intent-filter>
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:scheme="content"
-                    android:mimeType="application/octet-stream"
-                    android:pathPattern=".*\\.json" />
-                <data
-                    android:scheme="content"
-                    android:mimeType="application/json"
-                    android:pathPattern=".*\\.json" />
+                <data android:scheme="content"/>
+                <data android:mimeType="application/octet-stream"/>
+                <data android:mimeType="application/json"/>
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/xargsgrep/portknocker/activity/HostListActivity.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/activity/HostListActivity.java
@@ -168,21 +168,17 @@ public class HostListActivity extends ActionBarActivity
     }
 
     private String getFileName(Uri uri) {
-        String result = "";
-        if("content".equals(uri.getScheme())) {
-            Cursor cursor = getContentResolver().query(uri, null, null, null, null);
+        String result = null;
+        Cursor cursor = getContentResolver().query(uri, null, null, null, null);
+        if (cursor != null) {
             try {
-                if (cursor != null && cursor.moveToFirst()) {
+                if (cursor.moveToFirst()) {
                     result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
                 }
             } finally {
-                if (cursor != null) {
-                    cursor.close();
-                }
+                cursor.close();
             }
-        }
-        else {
-            // In case of "file" scheme, we can get it per getPath
+        } else {
             result = uri.getPath();
         }
         return result;

--- a/app/src/main/java/com/xargsgrep/portknocker/utils/SerializationUtils.java
+++ b/app/src/main/java/com/xargsgrep/portknocker/utils/SerializationUtils.java
@@ -1,5 +1,8 @@
 package com.xargsgrep.portknocker.utils;
 
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 
@@ -10,6 +13,7 @@ import com.xargsgrep.portknocker.model.Host;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.InputStream;
 import java.util.List;
 
 public class SerializationUtils
@@ -44,7 +48,7 @@ public class SerializationUtils
         return storageDir;
     }
 
-    public static List<Host> deserializeHosts(String filePath) throws Exception
+    public static List<Host> deserializeHosts(Context context, Uri fileUri) throws Exception
     {
         if (!isExternalStorageAccessible())
         {
@@ -52,7 +56,10 @@ public class SerializationUtils
         }
 
         ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(new File(filePath), new TypeReference<List<Host>>() {});
+        ContentResolver resolver = context.getContentResolver();
+        InputStream input = resolver.openInputStream(fileUri);
+
+        return objectMapper.readValue(input, new TypeReference<List<Host>>() {});
     }
 
     private static boolean isExternalStorageAccessible()

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,5 +19,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 03 23:52:13 PST 2016
+#Sat Dec 30 16:35:25 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
I noticed on my new Android 7 smartphone, that file access was not working correctly. It seems "file://" URIs are not working well anymore in Android 7 due to access right changes. Instead "content://" shall be used, providing the correct rights. I have changed it in the file chooser and in the handling of URI of the port knocker class.
Additionally the intent-filter was not working with the e-mail client on the new phone, so intent-filter was adapted.
Rest of changes are updates due to Android Studio updates.
