### PR TITLE
Fix minSDKVersion

### DIFF
--- a/FileChooser/build.gradle
+++ b/FileChooser/build.gradle
@@ -2,10 +2,9 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '26.0.2'
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 25
     }
 
@@ -18,5 +17,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.4.0'
+    implementation 'com.android.support:support-v4:25.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.xargsgrep.portknocker"
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 25
-        versionCode 13
-        versionName "1.0.12"
+        versionCode 14
+        versionName "1.0.13"
     }
     signingConfigs {
         release {
@@ -32,9 +31,9 @@ android {
 }
 
 dependencies {
-    compile project(':FileChooser')
+    implementation project(':FileChooser')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.5.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.4.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.5.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,10 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 30 16:35:25 CET 2017
+#Fri Mar 30 14:55:40 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
+ bump to Android Studio version 3.1.0 and gradle 4.4. 
+ Removed buildToolsVersion as not required anymore. 
+ Changed 'compile' to 'implementation' in gradle files, as compile will no longer be supported in future.